### PR TITLE
Remvoe the echo parameter

### DIFF
--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -130,29 +130,29 @@ end
 
 local send = function(file_type)
     -- Block
-    create_maps("ni",  "RSendMBlock",      "bb", "<Cmd>lua require('r.send').marked_block('stay')")
-    create_maps("ni",  "RDSendMBlock",     "bd", "<Cmd>lua require('r.send').marked_block('down')")
+    create_maps("ni",  "RSendMBlock",      "bb", "<Cmd>lua require('r.send').marked_block(false)")
+    create_maps("ni",  "RDSendMBlock",     "bd", "<Cmd>lua require('r.send').marked_block(true)")
 
     -- Function
     -- Not currently implemented
-    -- create_maps("nvi", "RSendFunction",    "ff", "<Cmd>lua require('r.send').fun('stay')")
-    -- create_maps("nvi", "RDSendFunction",   "fd", "<Cmd>lua require('r.send').fun('down')")
+    -- create_maps("nvi", "RSendFunction",    "ff", "<Cmd>lua require('r.send').fun(false)")
+    -- create_maps("nvi", "RDSendFunction",   "fd", "<Cmd>lua require('r.send').fun(true)")
 
     -- Selection
-    create_maps("nv",   "RSendSelection",   "ss", "<Cmd>lua require('r.send').selection('stay')")
-    create_maps("nv",   "RDSendSelection",  "sd", "<Cmd>lua require('r.send').selection('down')")
+    create_maps("nv",   "RSendSelection",   "ss", "<Cmd>lua require('r.send').selection(false)")
+    create_maps("nv",   "RDSendSelection",  "sd", "<Cmd>lua require('r.send').selection(true)")
 
     -- Paragraph
-    create_maps("ni", "RSendParagraph",   "pp", "<Cmd>lua require('r.send').paragraph('stay')")
-    create_maps("ni", "RDSendParagraph",  "pd", "<Cmd>lua require('r.send').paragraph('down')")
+    create_maps("ni", "RSendParagraph",   "pp", "<Cmd>lua require('r.send').paragraph(false)")
+    create_maps("ni", "RDSendParagraph",  "pd", "<Cmd>lua require('r.send').paragraph(true)")
 
     if file_type == "rnoweb" or file_type == "rmd" or file_type == "quarto" then
         create_maps("ni", "RSendChunkFH", "ch", "<Cmd>lua require('r.send').chunks_up_to_here()")
     end
 
     -- *Line*
-    create_maps("ni",  "RSendLine",           "l",        "<Cmd>lua require('r.send').line('stay')")
-    create_maps("ni0", "RDSendLine",          "d",        "<Cmd>lua require('r.send').line('down')")
+    create_maps("ni",  "RSendLine",           "l",        "<Cmd>lua require('r.send').line(false)")
+    create_maps("ni0", "RDSendLine",          "d",        "<Cmd>lua require('r.send').line(true)")
     create_maps("ni0", "(RInsertLineOutput)", "o",        "<Cmd>lua require('r.run').insert_commented()")
     create_maps("v",   "(RInsertLineOutput)", "o",        "<Cmd>lua require('r').warn('This command does not work over a selection of lines.')")
     create_maps("i",   "RSendLAndOpenNewOne", "q",        "<Cmd>lua require('r.send').line('newline')")
@@ -169,8 +169,8 @@ local send = function(file_type)
     end
     if file_type == "rmd" or file_type == "quarto" then
         create_maps("nvi", "RKnit",           "kn", "<Cmd>lua require('r.run').knit()")
-        create_maps("ni",  "RSendChunk",      "cc", "<Cmd>lua require('r.rmd').send_R_chunk('stay')")
-        create_maps("ni",  "RDSendChunk",     "cd", "<Cmd>lua require('r.rmd').send_R_chunk('down')")
+        create_maps("ni",  "RSendChunk",      "cc", "<Cmd>lua require('r.rmd').send_R_chunk(false)")
+        create_maps("ni",  "RDSendChunk",     "cd", "<Cmd>lua require('r.rmd').send_R_chunk(true)")
         create_maps("n",   "RNextRChunk",     "gn", "<Cmd>lua require('r.rmd').next_chunk()")
         create_maps("n",   "RPreviousRChunk", "gN", "<Cmd>lua require('r.rmd').previous_chunk()")
     end
@@ -189,8 +189,8 @@ local send = function(file_type)
         create_maps("nvi", "RKnit",        "kn", "<Cmd>lua require('r.rnw').weave('nobib',  true, false)")
         create_maps("nvi", "RMakePDFK",    "kp", "<Cmd>lua require('r.rnw').weave('nobib',  true, true)")
         create_maps("nvi", "RBibTeXK",     "kb", "<Cmd>lua require('r.rnw').weave('bibtex', true, true)")
-        create_maps("ni",  "RSendChunk",   "cc", "<Cmd>lua require('r.rnw').send_chunk('stay')")
-        create_maps("ni",  "RDSendChunk",  "cd", "<Cmd>lua require('r.rnw').send_chunk('down')")
+        create_maps("ni",  "RSendChunk",   "cc", "<Cmd>lua require('r.rnw').send_chunk(false)")
+        create_maps("ni",  "RDSendChunk",  "cd", "<Cmd>lua require('r.rnw').send_chunk(true)")
         create_maps("nvi", "ROpenPDF",     "op", "<Cmd>lua require('r.pdf').open('Get Master')")
         if config.synctex then
             create_maps("ni", "RSyncFor", "gp", "<Cmd>lua require('r.rnw').SyncTeX_forward(false)")

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -130,28 +130,21 @@ end
 
 local send = function(file_type)
     -- Block
-    create_maps("ni",  "RSendMBlock",      "bb", "<Cmd>lua require('r.send').marked_block('silent', 'stay')")
-    create_maps("ni",  "RESendMBlock",     "be", "<Cmd>lua require('r.send').marked_block('echo',   'stay')")
-    create_maps("ni",  "RDSendMBlock",     "bd", "<Cmd>lua require('r.send').marked_block('silent', 'down')")
-    create_maps("ni",  "REDSendMBlock",    "ba", "<Cmd>lua require('r.send').marked_block('echo',   'down')")
+    create_maps("ni",  "RSendMBlock",      "bb", "<Cmd>lua require('r.send').marked_block('stay')")
+    create_maps("ni",  "RDSendMBlock",     "bd", "<Cmd>lua require('r.send').marked_block('down')")
 
     -- Function
-    create_maps("nvi", "RSendFunction",    "ff", "<Cmd>lua require('r.send').fun('silent', 'stay')")
-    create_maps("nvi", "RDSendFunction",   "fe", "<Cmd>lua require('r.send').fun('echo',   'stay')")
-    create_maps("nvi", "RDSendFunction",   "fd", "<Cmd>lua require('r.send').fun('silent', 'down')")
-    create_maps("nvi", "RDSendFunction",   "fa", "<Cmd>lua require('r.send').fun('echo',   'down')")
+    -- Not currently implemented
+    -- create_maps("nvi", "RSendFunction",    "ff", "<Cmd>lua require('r.send').fun('stay')")
+    -- create_maps("nvi", "RDSendFunction",   "fd", "<Cmd>lua require('r.send').fun('down')")
 
     -- Selection
-    create_maps("nv",   "RSendSelection",   "ss", "<Cmd>lua require('r.send').selection('silent', 'stay')")
-    create_maps("nv",   "RESendSelection",  "se", "<Cmd>lua require('r.send').selection('echo',   'stay')")
-    create_maps("nv",   "RDSendSelection",  "sd", "<Cmd>lua require('r.send').selection('silent', 'down')")
-    create_maps("nv",   "REDSendSelection", "sa", "<Cmd>lua require('r.send').selection('echo',   'down')")
+    create_maps("nv",   "RSendSelection",   "ss", "<Cmd>lua require('r.send').selection('stay')")
+    create_maps("nv",   "RDSendSelection",  "sd", "<Cmd>lua require('r.send').selection('down')")
 
     -- Paragraph
-    create_maps("ni", "RSendParagraph",   "pp", "<Cmd>lua require('r.send').paragraph('silent', 'stay')")
-    create_maps("ni", "RESendParagraph",  "pe", "<Cmd>lua require('r.send').paragraph('echo',   'stay')")
-    create_maps("ni", "RDSendParagraph",  "pd", "<Cmd>lua require('r.send').paragraph('silent', 'down')")
-    create_maps("ni", "REDSendParagraph", "pa", "<Cmd>lua require('r.send').paragraph('echo',   'down')")
+    create_maps("ni", "RSendParagraph",   "pp", "<Cmd>lua require('r.send').paragraph('stay')")
+    create_maps("ni", "RDSendParagraph",  "pd", "<Cmd>lua require('r.send').paragraph('down')")
 
     if file_type == "rnoweb" or file_type == "rmd" or file_type == "quarto" then
         create_maps("ni", "RSendChunkFH", "ch", "<Cmd>lua require('r.send').chunks_up_to_here()")
@@ -176,10 +169,8 @@ local send = function(file_type)
     end
     if file_type == "rmd" or file_type == "quarto" then
         create_maps("nvi", "RKnit",           "kn", "<Cmd>lua require('r.run').knit()")
-        create_maps("ni",  "RSendChunk",      "cc", "<Cmd>lua require('r.rmd').send_R_chunk('silent', 'stay')")
-        create_maps("ni",  "RESendChunk",     "ce", "<Cmd>lua require('r.rmd').send_R_chunk('echo',   'stay')")
-        create_maps("ni",  "RDSendChunk",     "cd", "<Cmd>lua require('r.rmd').send_R_chunk('silent', 'down')")
-        create_maps("ni",  "REDSendChunk",    "ca", "<Cmd>lua require('r.rmd').send_R_chunk('echo',   'down')")
+        create_maps("ni",  "RSendChunk",      "cc", "<Cmd>lua require('r.rmd').send_R_chunk('stay')")
+        create_maps("ni",  "RDSendChunk",     "cd", "<Cmd>lua require('r.rmd').send_R_chunk('down')")
         create_maps("n",   "RNextRChunk",     "gn", "<Cmd>lua require('r.rmd').next_chunk()")
         create_maps("n",   "RPreviousRChunk", "gN", "<Cmd>lua require('r.rmd').previous_chunk()")
     end
@@ -198,10 +189,8 @@ local send = function(file_type)
         create_maps("nvi", "RKnit",        "kn", "<Cmd>lua require('r.rnw').weave('nobib',  true, false)")
         create_maps("nvi", "RMakePDFK",    "kp", "<Cmd>lua require('r.rnw').weave('nobib',  true, true)")
         create_maps("nvi", "RBibTeXK",     "kb", "<Cmd>lua require('r.rnw').weave('bibtex', true, true)")
-        create_maps("ni",  "RSendChunk",   "cc", "<Cmd>lua require('r.rnw').send_chunk('silent', 'stay')")
-        create_maps("ni",  "RESendChunk",  "ce", "<Cmd>lua require('r.rnw').send_chunk('echo',   'stay')")
-        create_maps("ni",  "RDSendChunk",  "cd", "<Cmd>lua require('r.rnw').send_chunk('silent', 'down')")
-        create_maps("ni",  "REDSendChunk", "ca", "<Cmd>lua require('r.rnw').send_chunk('echo',   'down')")
+        create_maps("ni",  "RSendChunk",   "cc", "<Cmd>lua require('r.rnw').send_chunk('stay')")
+        create_maps("ni",  "RDSendChunk",  "cd", "<Cmd>lua require('r.rnw').send_chunk('down')")
         create_maps("nvi", "ROpenPDF",     "op", "<Cmd>lua require('r.pdf').open('Get Master')")
         if config.synctex then
             create_maps("ni", "RSyncFor", "gp", "<Cmd>lua require('r.rnw').SyncTeX_forward(false)")

--- a/lua/r/paragraph.lua
+++ b/lua/r/paragraph.lua
@@ -21,7 +21,7 @@ M.get_current = function()
         end_line = end_line + 1
     end
 
-    return start_line, end_line
+    return start_line - 1, end_line
 end
 
 return M

--- a/lua/r/rmd.lua
+++ b/lua/r/rmd.lua
@@ -58,7 +58,7 @@ local send_py_chunk = function(m)
     local lines = vim.fn.getline(chunkline, docline)
     local ok = send.source_lines(lines, "PythonCode")
     if ok == 0 then return end
-    if m == "down" then M.RmdNextChunk() end
+    if m == true then M.RmdNextChunk() end
 end
 
 -- Send R chunk to R
@@ -77,7 +77,7 @@ M.send_R_chunk = function(m)
     local lines = vim.fn.getline(chunkline, docline)
     local ok = send.source_lines(lines, "chunk")
     if ok == 0 then return end
-    if m == "down" then M.next_chunk() end
+    if m == true then M.next_chunk() end
 end
 
 M.previous_chunk = function()

--- a/lua/r/rmd.lua
+++ b/lua/r/rmd.lua
@@ -52,11 +52,11 @@ M.write_chunk = function()
 end
 
 -- Send Python chunk to R
-local send_py_chunk = function(e, m)
+local send_py_chunk = function(m)
     local chunkline = vim.fn.search("^[ \t]*```[ ]*{python", "bncW") + 1
     local docline = vim.fn.search("^[ \t]*```", "ncW") - 1
     local lines = vim.fn.getline(chunkline, docline)
-    local ok = send.source_lines(lines, e, "PythonCode")
+    local ok = send.source_lines(lines, "PythonCode")
     if ok == 0 then return end
     if m == "down" then M.RmdNextChunk() end
 end
@@ -68,14 +68,14 @@ M.send_R_chunk = function(m)
         if M.is_in_Py_code(0) == 0 then
             warn("Not inside an R code chunk.")
         else
-            send_py_chunk(e, m)
+            send_py_chunk(m)
         end
         return
     end
     local chunkline = vim.fn.search("^[ \t]*```[ ]*{r", "bncW") + 1
     local docline = vim.fn.search("^[ \t]*```", "ncW") - 1
     local lines = vim.fn.getline(chunkline, docline)
-    local ok = send.source_lines(lines, e, "chunk")
+    local ok = send.source_lines(lines, "chunk")
     if ok == 0 then return end
     if m == "down" then M.next_chunk() end
 end

--- a/lua/r/rmd.lua
+++ b/lua/r/rmd.lua
@@ -62,7 +62,7 @@ local send_py_chunk = function(e, m)
 end
 
 -- Send R chunk to R
-M.send_R_chunk = function(e, m)
+M.send_R_chunk = function(m)
     if M.is_in_R_code(0) == 2 then vim.fn.cursor(vim.fn.line(".") + 1, 1) end
     if M.is_in_R_code(0) ~= 1 then
         if M.is_in_Py_code(0) == 0 then

--- a/lua/r/rnw.lua
+++ b/lua/r/rnw.lua
@@ -289,7 +289,7 @@ M.weave = function(bibtex, knit, pdf)
 end
 
 -- Send Sweave chunk to R
-M.send_chunk = function(e, m)
+M.send_chunk = function(m)
     local chunk_type = M.is_in_R_code(true)
     if chunk_type == 2 then
         vim.api.nvim_win_set_cursor(0, { vim.fn.line(".") + 1, 1 })

--- a/lua/r/rnw.lua
+++ b/lua/r/rnw.lua
@@ -300,7 +300,7 @@ M.send_chunk = function(m)
     local chunkline = vim.fn.search("^<<", "bncW") + 1
     local docline = vim.fn.search("^@", "ncW") - 1
     local lines = vim.fn.getline(chunkline, docline)
-    local ok = send.source_lines(lines, e, "chunk")
+    local ok = send.source_lines(lines, "chunk")
     if ok == 0 then return end
 
     if m == "down" then M.next_chunk() end

--- a/lua/r/rnw.lua
+++ b/lua/r/rnw.lua
@@ -303,7 +303,7 @@ M.send_chunk = function(m)
     local ok = send.source_lines(lines, "chunk")
     if ok == 0 then return end
 
-    if m == "down" then M.next_chunk() end
+    if m == true then M.next_chunk() end
 end
 
 M.SyncTeX_get_master = function()

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -311,7 +311,7 @@ M.marked_block = function(m)
     if lineB < vim.fn.line("$") then lineB = lineB - 1 end
 
     local lines = vim.fn.getline(lineA, lineB)
-    local ok = M.source_lines(lines, e, "block")
+    local ok = M.source_lines(lines, "block")
 
     if ok == 0 then return end
 
@@ -395,14 +395,14 @@ M.selection = function(m)
 
     local ok
     if ispy then
-        ok = M.source_lines(lines, e, "PythonCode")
+        ok = M.source_lines(lines, "PythonCode")
     else
-        ok = M.source_lines(lines, e, "selection")
+        ok = M.source_lines(lines, "selection")
     end
 
     if ok == 0 then return end
 
-    if e == "down" then cursor.move_next_line() end
+    if m == "down" then cursor.move_next_line() end
 end
 
 --- Send current line to R Console

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -279,7 +279,7 @@ end
 
 -- Send block to R (Adapted from marksbrowser plugin)
 -- Function to get the marks which the cursor is between
-M.marked_block = function(e, m)
+M.marked_block = function(m)
     if vim.o.filetype ~= "r" and not vim.b.IsInRCode(true) then return end
 
     local curline = vim.fn.line(".")
@@ -321,7 +321,7 @@ M.marked_block = function(e, m)
     end
 end
 
-M.selection = function(e, m)
+M.selection = function(m)
     local ispy = false
 
     if vim.o.filetype ~= "r" then

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -175,7 +175,7 @@ M.paragraph = function(m)
     local lines = vim.api.nvim_buf_get_lines(0, start_line, end_line, false)
     M.cmd(table.concat(lines, "\n"))
 
-    if m == "down" then cursor.move_next_paragraph() end
+    if m == true then cursor.move_next_paragraph() end
 end
 
 M.line_part = function(direction, correctpos)
@@ -315,7 +315,7 @@ M.marked_block = function(m)
 
     if ok == 0 then return end
 
-    if m == "down" and lineB ~= vim.fn.line("$") then
+    if m == true and lineB ~= vim.fn.line("$") then
         vim.fn.cursor(lineB, 1)
         cursor.move_next_line()
     end
@@ -357,7 +357,7 @@ M.selection = function(m)
         local line = string.sub(l, i, i + j)
         if vim.o.filetype == "r" then line = cursor.clean_oxygen_line(line) end
         local ok = M.cmd(line)
-        if ok and m == "down" then cursor.move_next_line() end
+        if ok and m == true then cursor.move_next_line() end
         return
     end
 
@@ -402,27 +402,27 @@ M.selection = function(m)
 
     if ok == 0 then return end
 
-    if m == "down" then cursor.move_next_line() end
+    if m == true then cursor.move_next_line() end
 end
 
 --- Send current line to R Console
----@param move string Movement to do after sending the line.
+---@param m string Movement to do after sending the line.
 ---@param lnum number Number of line to send (optional).
-M.line = function(move, lnum)
+M.line = function(m, lnum)
     if not lnum then lnum = vim.fn.line(".") end
     local line = vim.fn.getline(lnum)
     if #line == 0 then
-        if move == "down" then cursor.move_next_line() end
+        if m == true then cursor.move_next_line() end
         return
     end
 
     if vim.o.filetype == "rnoweb" then
         if line == "@" then
-            if move == "down" then cursor.move_next_line() end
+            if m == true then cursor.move_next_line() end
             return
         end
         if line:find("^<<.*child *= *") then
-            knit_child(lnum, move)
+            knit_child(lnum, m)
             return
         end
         if not require("r.rnw").is_in_R_code(true) then return end
@@ -430,11 +430,11 @@ M.line = function(move, lnum)
 
     if vim.o.filetype == "rmd" or vim.o.filetype == "quarto" then
         if line == "```" then
-            if move == "down" then cursor.move_next_line() end
+            if m == true then cursor.move_next_line() end
             return
         end
         if vim.fn.match(line, "^```.*child *= *") > -1 then
-            knit_child(lnum, move)
+            knit_child(lnum, m)
             return
         end
         line = vim.fn.substitute(line, "^(\\`\\`)\\?", "", "")
@@ -507,9 +507,9 @@ M.line = function(move, lnum)
         M.cmd(line)
     end
 
-    if move == "down" then
+    if m == true then
         cursor.move_next_line()
-    elseif move == "newline" then
+    elseif m == "newline" then
         vim.cmd("normal! o")
     end
 end


### PR DESCRIPTION
refactor(maps.lua): remove unnecessary file_type parameter from send function
refactor(maps.lua): simplify create_maps calls by removing unnecessary 'silent' and 'echo' arguments
refactor(rmd.lua): remove unused 'e' parameter from send_R_chunk function
refactor(rnw.lua): remove unused 'e' parameter from send_chunk function
refactor(send.lua): remove unused 'e' parameter from marked_block and selection functions

I think we will have to also remove the `M.get_source_args` in `source_file` and only call it once just before sending the code to the terminal.