### PR TITLE
Use M.source_lines instead of M.cmd so we can send lines that contains function call spread over multiple lines

### DIFF
--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -149,11 +149,14 @@ end
 M.above_lines = function()
     local lines = vim.api.nvim_buf_get_lines(0, 0, vim.fn.line("."), false)
 
-    -- Remove empty lines from the end of the list
-    local result =
-        table.concat(vim.tbl_filter(function(line) return line ~= "" end, lines), "\n")
+    -- Remove empty lines
+    local filtered_lines = {}
 
-    M.cmd(result)
+    for _, line in ipairs(lines) do
+        if string.match(line, "%S") then table.insert(filtered_lines, line) end
+    end
+
+    M.source_lines(filtered_lines, nil)
 end
 
 M.source_file = function()


### PR DESCRIPTION
For example, sending these lines (using send above) was not working:

```r
library(tidyverse)

mtcars |>
  head() |>
  mutate(
    drat = drat / 2, hp
  ) |>
  mutate(y = 1 + 1)
```

Because the `mutate()` call was spread over 3 lines, and each of these line were sent separately to the terminal. 